### PR TITLE
Minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-# Config file for automatic testing at travis-ci.org
-
 sudo: false
 language: python
+cache: pip
 
 matrix:
     include:
@@ -18,10 +17,3 @@ install:
 
 script:
   - tox -e $TOX_ENV
-
-before_cache:
-  - rm -rf $HOME/.cache/pip/log
-
-cache:
-  directories:
-    - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,13 @@ install:
 
 script:
   - tox -e $TOX_ENV
+
+after_success:
+  - |
+        pip install coveralls
+        coveralls
+
+notifications:
+  email:
+    on_failure: change
+    on_success: never

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,11 @@ kiwitcms-pytest-plugin
     :target: https://travis-ci.org/kiwitcms/pytest-plugin
     :alt: See Build Status on Travis CI
 
+.. image:: https://coveralls.io/repos/github/kiwitcms/pytest-plugin/badge.svg?branch=master
+    :target: https://coveralls.io/github/kiwitcms/pytest-plugin?branch=master
+    :alt: Code coverage
+
+
 Pytest plugin for Kiwi TCMS
 
 ----

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     author_email="dadygalo@gmail.com",
     maintainer="Kiwi TCMS",
     maintainer_email="info@kiwitcms.org",
-    license="GNU GPL v3.0",
     url="https://github.com/kiwitcms/pytest-plugin",
     description="Pytest plugin for Kiwi TCMS test case management system",
     long_description=README,


### PR DESCRIPTION
FYI I have updated demo.kiwitcms.org with a pre-release version which exposes the following API methods:
- Classification.filter()
- Product.create()
- TestCaseRunStatus.filter()

I will need a few more days to finish up my work for tap-plugin and move the helper functions under tcms-api, however you can use that as a temporary dependency while developing the rest of the plugin.