### PR TITLE
Add sanity test script for PyPI packages

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.7]
-        make-command: [doc8, flake8, pylint, test]
+        make-command: [doc8, flake8, pylint, test, check-build]
 
     steps:
       - name: Check out code
@@ -30,7 +30,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           sudo apt-get install virtualenv
+          pip install -U pip setuptools
           pip install -r devel.txt
+
       - name: Prepare for integration test
         if: matrix.make-command == 'test'
         run: |
@@ -40,6 +42,7 @@ jobs:
           echo "password = ${{ secrets.TCMS_PASSWORD }}" >> ~/.tcms.conf
           sudo cp .ssl/*.pem /usr/lib/ssl/certs/
           sudo update-ca-certificates --fresh
+
       - name: Verify ${{ matrix.make-command }}
         run: |
           export TCMS_PRODUCT=$GITHUB_REPOSITORY

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,7 @@ pylint:
 .PHONY: test
 test:
 	pytest --kiwitcms
+
+.PHONY: check-build
+check-build:
+	./tests/bin/check-build

--- a/devel.txt
+++ b/devel.txt
@@ -3,3 +3,5 @@
 doc8
 flake8
 pylint_django
+twine
+wheel

--- a/tests/bin/check-build
+++ b/tests/bin/check-build
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Build packages for distribution on PyPI
+# and execute some sanity checks on them
+#
+# note: must be executed from the root directory of the project
+
+# first clean up the local environment
+echo "..... Clean up first"
+find . -type f -name '*.pyc' -delete
+find . -type d -name __pycache__ -delete
+find . -type d -name '*.egg-info' | xargs rm -rf
+rm -rf build/ .cache/ dist/ .eggs/ .tox/ .venv/
+
+
+# then build the packages
+echo "..... Building PyPI packages"
+set -e
+$(which python) setup.py sdist >/dev/null
+$(which python) setup.py bdist_wheel >/dev/null
+set +e
+
+# check rst formatting of README
+echo "..... Check rst formatting for PyPI"
+twine check dist/* || exit 1
+
+# then run some sanity tests
+echo "..... Searching for .pyc files inside the built packages"
+matched_files=`tar -tvf dist/*.tar.gz | grep -c "\.pyc"`
+if [ "$matched_files" -gt "0" ]; then
+    echo "ERROR: .pyc files found in .tar.gz package"
+    exit 1
+fi
+
+matched_files=`unzip -t dist/*.whl | grep -c "\.pyc"`
+if [ "$matched_files" -gt "0" ]; then
+    echo "ERROR: .pyc files found in wheel package"
+    exit 1
+fi
+
+# exit on error from now on
+set -e
+
+echo "..... Trying to install the new tarball inside a virtualenv"
+virtualenv -q -p $(which python) .venv/test-tarball
+source .venv/test-tarball/bin/activate
+pip install --upgrade setuptools pip
+pip install --no-binary :all: -f dist/ kiwitcms-pytest-plugin
+pip freeze | grep kiwitcms-pytest-plugin
+deactivate
+rm -rf .venv/
+
+echo "..... Trying to install the new wheel inside a virtualenv"
+virtualenv -q -p $(which python) .venv/test-wheel
+source .venv/test-wheel/bin/activate
+pip install --upgrade setuptools pip
+pip install --only-binary :all: -f dist/ kiwitcms-pytest-plugin
+pip freeze | grep kiwitcms-pytest-plugin
+deactivate
+rm -rf .venv/
+
+echo "..... PASS"


### PR DESCRIPTION
@Stranger6667 - script works when executed from the terminal but I don't have enough experience with tox to make it work right now. Will spend some more time on it in the next few days but tips are welcome.

The script is what I generally use to build and sanity check packages before uploading them to PyPI. it also serves as a starting point to later add additional checks when issues are discovered.