### PR TITLE
Require tcms-api v5.1 for plugin_helpers.Backend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest==4.1.1
+tcms-api==5.1


### PR DESCRIPTION
For usage see:
https://github.com/kiwitcms/tap-plugin/commit/634c6c36383d7c5f2548f5d76018af7dd2ff11ae

we'll try to keep all behaviour about creating objects in the DB in the `plugin_helpers` module and the testrunner plugin itself should only be concerned how to parse the results and call the helper functions to send the information back to Kiwi TCMS. This will result in very small plugin packages and the same behavior across everything implemented in Python.